### PR TITLE
Benchmark dataclass with `slots=True`. Benchmark struct access (not creation), add `uv` command to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,17 @@ If you are familiar with Python and want to review code and measurements as you 
 ```sh
 pytest less_slow.py
 ```
+
+## Running with `uv`
+
+If you have `uv` installed, you can run the benchmarks with the following command.
+
+```sh
+uv run --python=">=3.10" --no-sync \
+--with "pytest" \
+--with "pytest-benchmark" \
+--with "numpy" \
+--with "pandas" \
+--with "pyarrow" \
+pytest -ra -q less_slow.py
+```

--- a/less_slow.py
+++ b/less_slow.py
@@ -553,8 +553,9 @@ def test_structs_dataclass(benchmark):
     assert result == 3.0
 
 
-@dataclass(slots=True)
+@dataclass
 class PointSlotsDataclass:
+    __slots__ = ("x", "y", "flag")
     x: float
     y: float
     flag: bool

--- a/less_slow.py
+++ b/less_slow.py
@@ -617,7 +617,7 @@ def test_structs_tuple_unpacking(benchmark):
 
 
 @pytest.mark.benchmark(group="composite-structs-access")
-def test_structs_dict_access(benchmark):
+def test_structs_access_dict(benchmark):
     point = {"x": 1.0, "y": 2.0, "flag": True}
 
     def kernel():
@@ -628,7 +628,7 @@ def test_structs_dict_access(benchmark):
 
 
 @pytest.mark.benchmark(group="composite-structs-access")
-def test_structs_class_access(benchmark):
+def test_structs_access_class(benchmark):
     point = PointClass(1.0, 2.0, True)
 
     def kernel():
@@ -639,7 +639,7 @@ def test_structs_class_access(benchmark):
 
 
 @pytest.mark.benchmark(group="composite-structs-access")
-def test_structs_dataclass_access(benchmark):
+def test_structs_access_dataclass(benchmark):
     point = PointDataclass(1.0, 2.0, True)
 
     def kernel():
@@ -650,7 +650,7 @@ def test_structs_dataclass_access(benchmark):
 
 
 @pytest.mark.benchmark(group="composite-structs-access")
-def test_structs_slots_dataclass_access(benchmark):
+def test_structs_access_slots_dataclass(benchmark):
     point = PointSlotsDataclass(1.0, 2.0, True)
 
     def kernel():
@@ -661,7 +661,7 @@ def test_structs_slots_dataclass_access(benchmark):
 
 
 @pytest.mark.benchmark(group="composite-structs-access")
-def test_structs_namedtuple_access(benchmark):
+def test_structs_access_namedtuple(benchmark):
     point = PointNamedtuple(1.0, 2.0, True)
 
     def kernel():
@@ -672,7 +672,7 @@ def test_structs_namedtuple_access(benchmark):
 
 
 @pytest.mark.benchmark(group="composite-structs-access")
-def test_structs_tuple_indexing_access(benchmark):
+def test_structs_access_tuple_indexing(benchmark):
     point = (1.0, 2.0, True)
 
     def kernel():
@@ -683,7 +683,7 @@ def test_structs_tuple_indexing_access(benchmark):
 
 
 @pytest.mark.benchmark(group="composite-structs-access")
-def test_structs_tuple_unpacking_access(benchmark):
+def test_structs_access_tuple_unpacking(benchmark):
     x, y, _ = (1.0, 2.0, True)
 
     def kernel():

--- a/less_slow.py
+++ b/less_slow.py
@@ -553,6 +553,23 @@ def test_structs_dataclass(benchmark):
     assert result == 3.0
 
 
+@dataclass(slots=True)
+class PointSlotsDataclass:
+    x: float
+    y: float
+    flag: bool
+
+
+@pytest.mark.benchmark(group="composite-structs")
+def test_structs_slots_dataclass(benchmark):
+    def kernel():
+        point = PointSlotsDataclass(1.0, 2.0, True)
+        return point.x + point.y
+
+    result = benchmark(kernel)
+    assert result == 3.0
+
+
 PointNamedtuple = namedtuple("PointNamedtuple", ["x", "y", "flag"])
 
 

--- a/less_slow.py
+++ b/less_slow.py
@@ -614,6 +614,101 @@ def test_structs_tuple_unpacking(benchmark):
 # ? - Class: 125ns
 # ? - Namedtuple: 183ns
 
+
+@pytest.mark.benchmark(group="composite-structs-access")
+def test_structs_dict_access(benchmark):
+    point = {"x": 1.0, "y": 2.0, "flag": True}
+
+    def kernel():
+        return point["x"] + point["y"]
+
+    result = benchmark(kernel)
+    assert result == 3.0
+
+
+@pytest.mark.benchmark(group="composite-structs-access")
+def test_structs_class_access(benchmark):
+    point = PointClass(1.0, 2.0, True)
+
+    def kernel():
+        return point.x + point.y
+
+    result = benchmark(kernel)
+    assert result == 3.0
+
+
+@pytest.mark.benchmark(group="composite-structs-access")
+def test_structs_dataclass_access(benchmark):
+    point = PointDataclass(1.0, 2.0, True)
+
+    def kernel():
+        return point.x + point.y
+
+    result = benchmark(kernel)
+    assert result == 3.0
+
+
+@pytest.mark.benchmark(group="composite-structs-access")
+def test_structs_slots_dataclass_access(benchmark):
+    point = PointSlotsDataclass(1.0, 2.0, True)
+
+    def kernel():
+        return point.x + point.y
+
+    result = benchmark(kernel)
+    assert result == 3.0
+
+
+@pytest.mark.benchmark(group="composite-structs-access")
+def test_structs_namedtuple_access(benchmark):
+    point = PointNamedtuple(1.0, 2.0, True)
+
+    def kernel():
+        return point.x + point.y
+
+    result = benchmark(kernel)
+    assert result == 3.0
+
+
+@pytest.mark.benchmark(group="composite-structs-access")
+def test_structs_tuple_indexing_access(benchmark):
+    point = (1.0, 2.0, True)
+
+    def kernel():
+        return point[0] + point[1]
+
+    result = benchmark(kernel)
+    assert result == 3.0
+
+
+@pytest.mark.benchmark(group="composite-structs-access")
+def test_structs_tuple_unpacking_access(benchmark):
+    x, y, _ = (1.0, 2.0, True)
+
+    def kernel():
+        return x + y
+
+    result = benchmark(kernel)
+    assert result == 3.0
+
+
+# ? When accessing pre-constructed objects, the performance gap narrows
+# ? significantly, and some relationships even reverse:
+# ?
+# ? - Tuple unpacking: 41ns
+# ? - Slots dataclass: 44ns
+# ? - Regular class: 45ns
+# ? - Regular dataclass: 45ns
+# ? - Tuple indexing: 46ns
+# ? - Dict: 51ns
+# ? - Namedtuple: 59ns
+# ?
+# ? The tuple unpacking is still the fastest, but slots dataclasses are now
+# ? very competitive, beating tuple indexing. The dict access is now
+# ? slower than most alternatives, showing that the initial construction
+# ? overhead isn't everything. Namedtuples are still the slowest.
+
+
 # endregion: Composite Structs
 
 # region: Heterogenous Collections


### PR DESCRIPTION
Hi! Thanks for these benchmarks. I'm making this "draft" PR mainly as a point of discussion, I put different (unrelated) changes which could probably be split into different PRs if any of these changes are welcome.

1. Benchmark dataclasses with `slots=True`

This is my first go-to when trying to make programs more memory efficient. I know this benchmark doesn't measure memory usage, but I think it could be a nice "good to have". `@dataclass(slots=True)` is only available in since Python 3.10, thought. If compatibility with python >= 3.8 is needed, I can add the `__slots__` manually.

2. Benchmark attribute access

I think one issue with the "composite-structs" benchmarks is that it mixes object creation with attribute access. But in some cases, one of those actions may be more prevalent than the other. I add a `composite-structs-access` group to measure attribute access only. It shows different results than then ones in `composite-structs` (although, surprisingly, the `namedtuple` access is still the slowest)

3. Better reproducibility

~I noticed that the `pyproject.toml` file doesn't properly list all the dependencies needed to run the script~

I see this was just fixed in https://github.com/ashvardanian/less_slow.py/commit/9a5ffbb86419e64fa8c6ae615e415bb57fba374e

In any case, I found it useful to have a single `uv` command that allows running the script, and could even be useful to run the benchmark with different Python versions. I'm not sure if this is something that could be nice to add to the README.