### PR TITLE
Benchmark dataclass slots with __slots__, add instructions to run the benchmark with `uv`

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,22 @@ If you are familiar with Python and want to review code and measurements as you 
 ```sh
 pytest less_slow.py
 ```
+
+## Running benchmarks with `uv`
+
+If you have `uv` installed, you can run the benchmark script with it. This also
+allows running the script with different Python versions. Here is an example of
+running the script with Python 3.12.
+
+The `--no-sync` flag is used to prevent `uv` from creating an uv.lock file or
+modifying an existing `.venv` folder.
+
+```sh
+uv run --python="3.12" --no-sync \
+--with "pytest" \
+--with "pytest-benchmark" \
+--with "numpy" \
+--with "pandas" \
+--with "pyarrow" \
+pytest -ra -q less_slow.py
+```

--- a/less_slow.py
+++ b/less_slow.py
@@ -611,6 +611,7 @@ def test_structs_tuple_unpacking(benchmark):
 # ?
 # ? - Tuple: 47ns (indexing) vs 43ns (unpacking)
 # ? - Dict:  101ns
+# ? - Slots Dataclass: 112ns
 # ? - Dataclass: 122ns
 # ? - Class: 125ns
 # ? - Namedtuple: 183ns

--- a/less_slow.py
+++ b/less_slow.py
@@ -553,6 +553,24 @@ def test_structs_dataclass(benchmark):
     assert result == 3.0
 
 
+@dataclass
+class PointSlotsDataclass:
+    __slots__ = ("x", "y", "flag")
+    x: float
+    y: float
+    flag: bool
+
+
+@pytest.mark.benchmark(group="composite-structs")
+def test_structs_slots_dataclass(benchmark):
+    def kernel():
+        point = PointSlotsDataclass(1.0, 2.0, True)
+        return point.x + point.y
+
+    result = benchmark(kernel)
+    assert result == 3.0
+
+
 PointNamedtuple = namedtuple("PointNamedtuple", ["x", "y", "flag"])
 
 


### PR DESCRIPTION
Based on the discussion in #1 

This PR introduces a benchmark for a `dataclass` with `__slots__`. It also updates the README to show how to run the benchmarks using `uv`. The command can be used as a "base" for other benchmark runs (different Python versions, different versions of each dependency, etc.)

The results for the "composite-structs" benchmarks when running locally (MacBook M1 Pro, 32GB RAM):

```sh
uv run --python-preference="only-managed" --python="3.12" --no-sync --with "pytest" --with "pytest-benchmark" --with "numpy" --with "pandas" --with "pyarrow" pytest -ra -q -k test_structs --benchmark-columns="min, max, mean, stddev, median, outliers, rounds, iterations" --benchmark-sort="mean" less_slow.py
```

```
-------------------------------------------------------------- benchmark 'composite-structs': 7 tests -------------------------------------------------------------
Name (time in ns)                     Min                    Max                Mean             StdDev              Median            Outliers  Rounds  Iterations
-------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_structs_tuple_unpacking      44.2882 (1.0)         552.9279 (1.0)       45.4682 (1.0)       3.3701 (1.0)       45.4146 (1.0)      336;6464  196696         111
test_structs_tuple_indexing       45.9904 (1.04)        569.5757 (1.03)      47.2578 (1.04)      4.2103 (1.25)      47.1699 (1.04)     287;5257  200000         106
test_structs_dict                 88.1249 (1.99)        616.8750 (1.12)      89.3393 (1.96)      5.0857 (1.51)      89.1650 (1.96)     201;1539   55683         200
test_structs_slots_dataclass     127.1285 (2.87)      2,034.2055 (3.68)     131.6381 (2.90)     10.3979 (3.09)     131.4098 (2.89)     609;9364  193536          39
test_structs_class               138.0860 (3.12)      1,929.7719 (3.49)     143.2161 (3.15)     12.5583 (3.73)     142.8574 (3.15)     307;8931  198334          35
test_structs_dataclass           138.0860 (3.12)      4,899.9999 (8.86)     143.7293 (3.16)     24.2981 (7.21)     142.8574 (3.15)    320;22881  200000          35
test_structs_namedtuple          165.9791 (3.75)     14,916.9937 (26.98)    243.0580 (5.35)     84.4260 (25.05)    250.0019 (5.50)    267;42132  171439           1
-------------------------------------------------------------------------------------------------------------------------------------------------------------------

Legend:
  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.
  OPS: Operations Per Second, computed as 1 / Mean

```