### PR TITLE
Add: Struct dict function variant

### DIFF
--- a/less_slow.py
+++ b/less_slow.py
@@ -541,6 +541,14 @@ def test_structs_dict(benchmark):
     result = benchmark(kernel)
     assert result == 3.0
 
+@pytest.mark.benchmark(group="composite-structs")
+def test_structs_dict_fun(benchmark):
+    def kernel():
+        point = dict(x=1.0, y=2.0, flag=True)
+        return point["x"] + point["y"]
+
+    result = benchmark(kernel)
+    assert result == 3.0
 
 class PointClass:
     def __init__(self, x: float, y: float, flag: bool) -> None:


### PR DESCRIPTION
Great resource!

I was reading through and wanted to add my two cents on the dict benchmark.
There's a difference between calling `dict` vs `{}`, for the first one, Python needs to lookup `dict` while the `{}` nomenclature cannot be overwritten, the bytecode says it all — https://godbolt.org/z/4497dfTG1

`{}`
```
  2           LOAD_CONST               1 ('x')
              LOAD_CONST               2 (10)
              BUILD_MAP                1
              RETURN_VALUE
```

`dict`
```
  6           LOAD_GLOBAL              1 (dict + NULL)
              LOAD_CONST               1 (10)
              LOAD_CONST               2 (('x',))
              CALL_KW                  1
              RETURN_VALUE
```

I was curious to see how they stack up, turns out, the difference is big enough that it can almost close the gap to the dataclass and friends — see `test_structs_dict_fun`

```
----------------------------------------------------------------------------------- benchmark 'composite-structs': 10 tests ------------------------------------------------------------------------------------
Name (time in ns)                     Min                    Max                Mean              StdDev              Median                IQR             Outliers  OPS (Mops/s)            Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_structs_tuple_unpacking      52.4998 (1.0)       1,118.3391 (1.61)      55.3057 (1.0)       11.7465 (1.67)      55.0004 (1.0)       1.6601 (3.94)     1175;1736       18.0813 (1.0)      180473         100
test_structs_tuple_indexing       53.7490 (1.02)        692.9203 (1.0)       56.7784 (1.03)       7.0220 (1.0)       56.6605 (1.03)      0.4214 (1.0)     1220;37751       17.6123 (0.97)     161081         100
test_structs_dict                101.6690 (1.94)        870.4094 (1.26)     106.3716 (1.92)      10.7967 (1.54)     105.4199 (1.92)      2.5099 (5.96)     1670;2190        9.4010 (0.52)      95238         100
test_structs_dict_fun            124.9998 (2.38)      1,146.2497 (1.65)     130.9408 (2.37)      10.0044 (1.42)     130.4201 (2.37)      1.2503 (2.97)     952;12269        7.6370 (0.42)      77671         100
test_structs_slots_dataclass     142.0791 (2.71)        875.8390 (1.26)     148.4811 (2.68)      11.4265 (1.63)     147.9208 (2.69)      1.2503 (2.97)     721;11753        6.7349 (0.37)      65933         100
test_structs_dataclass           147.1235 (2.80)      1,933.5966 (2.79)     156.0895 (2.82)      18.9933 (2.70)     154.9706 (2.82)      1.3169 (3.12)    1247;32677        6.4066 (0.35)     199999          32
test_structs_class               147.4994 (2.81)        767.9209 (1.11)     153.8915 (2.78)      10.7097 (1.53)     153.7497 (2.80)      2.0803 (4.94)      738;4708        6.4981 (0.36)      62500         100
test_structs_namedtuple          189.9991 (3.62)      2,618.3575 (3.78)     201.7096 (3.65)      24.9604 (3.55)     200.0015 (3.64)      3.3202 (7.88)    1857;15508        4.9576 (0.27)     195124          25
test_structs_attrs               457.9779 (8.72)     32,833.8938 (47.38)    533.1721 (9.64)     233.8386 (33.30)    540.9820 (9.84)     42.0259 (99.72)     371;2292        1.8756 (0.10)     130446           1
test_structs_pydantic            582.8915 (11.10)     3,000.0228 (4.33)     644.9098 (11.66)     98.3162 (14.00)    625.0339 (11.36)    40.9782 (97.24)        11;11        1.5506 (0.09)        779           1
```

I'm not sure if this is the content you're looking for but since you had other libraries, I think this could be an interesting find too.

I didn't add the takeaways to the file itself since I didn't get values near to yours, but I can add them if you want!